### PR TITLE
Correct hash function stub

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3906,7 +3906,7 @@ return [
 'HaruPage::stroke' => ['bool', 'close_path='=>'bool'],
 'HaruPage::textOut' => ['bool', 'x'=>'float', 'y'=>'float', 'text'=>'string'],
 'HaruPage::textRect' => ['bool', 'left'=>'float', 'top'=>'float', 'right'=>'float', 'bottom'=>'float', 'text'=>'string', 'align='=>'int'],
-'hash' => ['string', 'algo'=>'string', 'data'=>'string', 'raw_output='=>'bool'],
+'hash' => ['string|false', 'algo'=>'string', 'data'=>'string', 'raw_output='=>'bool'],
 'hash_algos' => ['array'],
 'hash_copy' => ['HashContext', 'context'=>'HashContext'],
 'hash_equals' => ['bool', 'known_string'=>'string', 'user_string'=>'string'],


### PR DESCRIPTION
Correct return type of the `hash` function. [The PHP docs](https://www.php.net/manual/en/function.hash.php) say that this function only returns a string, however this is not true. It can also return a boolean `false` if you pass in the name of a non-existent hash algorithm. For example:

    var_dump(@hash('foo', 'bar', true));
    bool(false)